### PR TITLE
Add E2B to dev-platforms

### DIFF
--- a/tools/dev-platforms/e2b.md
+++ b/tools/dev-platforms/e2b.md
@@ -1,0 +1,18 @@
+---
+name: E2B
+description: Secure cloud runtime for AI agents and code execution
+homepage: https://e2b.dev/enterprise
+github: https://github.com/e2b-dev/E2B
+docs: https://e2b.dev/docs/byoc
+category: dev-platforms
+tags:
+  - ai-agents
+  - sandboxes
+  - code-execution
+  - runtime
+license: open-source
+cloudSupport:
+  - aws
+  - gcp
+  - azure
+---


### PR DESCRIPTION
## Summary
- Add E2B (e2b.dev) to the dev-platforms category
- E2B provides secure cloud runtime for AI agents with BYOC support on AWS, GCP, and Azure

## Links
- Website: https://e2b.dev/enterprise
- Docs: https://e2b.dev/docs/byoc
- GitHub: https://github.com/e2b-dev/E2B