### PR TITLE
Remove 'What is BYOC?' from README contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ## Contents
 
 - [BYOC Tools](#byoc-tools)
-- [What is BYOC?](#what-is-byoc)
 - [Contributing](#contributing)
 
 ## BYOC Tools


### PR DESCRIPTION
Removed 'What is BYOC?' section from the contents list.