### PR TITLE
AnswerLayer Docs 404

### DIFF
--- a/tools/data-integration/answerlayer.md
+++ b/tools/data-integration/answerlayer.md
@@ -2,7 +2,7 @@
 name: AnswerLayer
 description: Generative semantic layer for natural language analytics on sensitive data
 homepage: https://getanswerlayer.com
-docs: https://docs.getanswerlayer.com
+docs: https://getanswerlayer.com/discover/build-vpc
 category: data-integration
 tags:
   - semantic-layer


### PR DESCRIPTION
Changed documentation link for AnswerLayer to an interactive BYOC explorer. Fixes #42 