### PR TITLE
fix(site): remove Google Analytics tracking script

### DIFF
--- a/.website/src/layouts/Layout.astro
+++ b/.website/src/layouts/Layout.astro
@@ -12,17 +12,6 @@ const { title, description = "Discover the best Bring Your Own Cloud infra tools
 <!doctype html>
 <html lang="en" data-theme="light">
   <head>
-
-        <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XM4126FT1J"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-    
-      gtag('config', 'G-XM4126FT1J');
-    </script>
-
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />


### PR DESCRIPTION
Google Analytics is no longer needed now that Vercel Web Analytics is being added as a replacement.