### PR TITLE
feat(site): add Plausible Analytics

### DIFF
--- a/.website/src/layouts/Layout.astro
+++ b/.website/src/layouts/Layout.astro
@@ -54,6 +54,13 @@ const { title, description = "Discover the best Bring Your Own Cloud infra tools
         }
       })();
     </script>
+
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-_1TJOnOIylPU8zcPf2tdF.js"></script>
+    <script is:inline>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
   </head>
   <body class="min-h-screen flex flex-col">
     <slot />


### PR DESCRIPTION
## Summary
- Adds Plausible Analytics tracking script to the site `<head>` in `Layout.astro`
- Plausible is a privacy-friendly, cookie-free analytics alternative
- Configured with outbound links, file downloads, and form submissions tracking

## Test plan
- [ ] Deploy preview and verify the Plausible script loads in the page `<head>`
- [ ] Click "Verify Script installation" in Plausible dashboard to confirm data is flowing
- [ ] Confirm no impact on page load performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)