### PR TITLE
Add Middleware in Observability tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Groundcover](https://www.groundcover.com/blog/why-byoc-is-the-future) - Cloud-native observability using eBPF for zero-instrumentation monitoring in Kubernetes.
 - [Honeycomb](https://www.honeycomb.io/blog/honeycomb-launches-new-private-cloud-offering-address-security-compliance-cost-concerns) - Observability platform for debugging distributed systems with high-cardinality data exploration.
 - [Last9](https://last9.io) - Managed Prometheus-compatible monitoring in your own cloud. ([Docs](https://last9.io/docs/))
+- [Middleware](https://middleware.io/) - Full-stack observability platform with on-prem cloud deployment support for logs, metrics, and traces. ([Docs](https://docs.middleware.io/onprem/prerequisites))
 - [SigNoz](https://signoz.io) - Open source full-stack observability with vendor-managed BYOC deployment. ([Docs](https://signoz.io/docs))
 
 ### Data Integration

--- a/tools/observability/middleware.md
+++ b/tools/observability/middleware.md
@@ -1,0 +1,18 @@
+---
+name: Middleware
+description: Full-stack observability platform with on-prem cloud deployment support for logs, metrics, and traces.
+homepage: https://middleware.io/
+docs: https://docs.middleware.io/onprem/prerequisites
+category: monitoring
+tags:
+  - observability
+  - metrics
+  - logs
+  - monitoring
+license: commercial
+logo: /logos/Middleware Logos.svg
+cloudSupport:
+  - aws
+  - gcp
+  - azure
+---


### PR DESCRIPTION
Adds Middleware in the BYOC observability tools list. I've also added relevant documentation on how to do so.

Here is the doc file FYR - https://docs.middleware.io/onprem/prerequisites