### PR TITLE
feat: add Vercel to dev platforms

### DIFF
--- a/.website/public/logos/vercel.svg
+++ b/.website/public/logos/vercel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1155 1000" fill="none" role="img" aria-label="Vercel logo"><path d="M577.344 0 1154.69 1000H0z" fill="#000"/></svg>

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [Okteto](https://www.okteto.com/) - Remote Development Environments for Humans and Agents.
 - [Ona](https://ona.com) - Mission control for software projects and AI agents.
 - [Rivet](https://rivet.dev/) - Infrastructure for stateful AI agents with Actor-based runtime. ([Source Code](https://github.com/rivet-gg/rivet))
+- [Vercel](https://vercel.com/enterprise) - Deploy enterprise apps and AI agents in your own cloud, with Vercel running the control plane.
 
 ### Apps
 

--- a/tools/dev-platforms/vercel.md
+++ b/tools/dev-platforms/vercel.md
@@ -1,0 +1,16 @@
+---
+name: Vercel
+description: Deploy enterprise apps and AI agents in your own cloud.
+homepage: https://vercel.com/enterprise
+category: dev-platforms
+tags:
+  - ai-agents
+  - deployment
+  - serverless
+  - frontend
+  - runtime
+license: commercial
+logo: /logos/vercel.svg
+cloudSupport:
+  - aws
+---


### PR DESCRIPTION
Vercel now offers Bring Your Own Cloud on AWS, deploying enterprise apps
and AI agents into the customer's own AWS account and VPC while Vercel
runs the control plane.
